### PR TITLE
Add/jetpack canary support

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const createHandler = require ( 'github-webhook-handler' );
 const url = require( 'url' );
 
 const calypsoProject = process.env.CALYPSO_PROJECT || 'Automattic/wp-calypso';
-const jetpackProject = process.env.JETPACK_PROJECT || 'Automattic/wp-calypso';
+const jetpackProject = process.env.JETPACK_PROJECT || 'Automattic/jetpack';
 const e2eTestsMainProject = process.env.E2E_MAIN_PROJECT || 'Automattic/wp-e2e-tests';
 const e2eTestsWrapperProject = process.env.E2E_WRAPPER_PROJECT || 'Automattic/wp-e2e-tests-for-branches';
 const e2eTestsWrapperBranch = process.env.E2E_WRAPPER_BRANCH || 'master';
@@ -226,7 +226,7 @@ handler.on('pull_request', function (event) {
                 e2eBranchName = 'master';
             }
             if ( label === jetpackCanaryTriggerLabel ) {
-                prContext = 'ci/wp-e2e-tests-canary';
+                prContext = 'ci/jetpack-e2e-tests-canary';
                 testFlag = '-J';
                 description = 'The e2e canary tests are running against your PR';
                 console.log( 'Executing JETPACK e2e canary tests for branch: \'' + branchName + '\'' );
@@ -238,7 +238,6 @@ handler.on('pull_request', function (event) {
 
             const buildParameters = {
                 build_parameters: {
-                    LIVEBRANCHES: 'true',
                     BRANCHNAME: branchName,
                     E2E_BRANCH: e2eBranchName,
                     RUN_ARGS: '-B ' + branchName,
@@ -267,7 +266,7 @@ handler.on('pull_request', function (event) {
                     };
                     request.post( {
                         headers: { Authorization: 'token ' + process.env.GITHUB_SECRET, 'User-Agent': 'wp-e2e-tests-gh-bridge' },
-                        url: gitHubCalypsoStatusURL + sha,
+                        url: gitHubJetpackStatusURL + sha,
                         body: JSON.stringify( gitHubStatus )
                     }, function( responseError ) {
                         if ( responseError ) {

--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ const e2eTestsMainProject = process.env.E2E_MAIN_PROJECT || 'Automattic/wp-e2e-t
 const e2eTestsWrapperProject = process.env.E2E_WRAPPER_PROJECT || 'Automattic/wp-e2e-tests-for-branches';
 const e2eTestsWrapperBranch = process.env.E2E_WRAPPER_BRANCH || 'master';
 
-const canaryTriggerLabel = process.env.TRIGGER_LABEL || '[Status] Needs Review';
-const fullSuiteTriggerLabel = process.env.FULL_SUITE_TRIGGER_LABEL || '[Status] Needs e2e Testing (BETA)';
+const calypsoCanaryTriggerLabel = process.env.CALYPSO_TRIGGER_LABEL || '[Status] Needs Review';
+const calypsoFullSuiteTriggerLabel = process.env.CALYPSO_FULL_SUITE_TRIGGER_LABEL || '[Status] Needs e2e Testing (BETA)';
 
 const triggerBuildURL = `https://circleci.com/api/v1.1/project/github/${ e2eTestsWrapperProject }/tree/${ e2eTestsWrapperBranch }?circle-token=${ process.env.CIRCLECI_SECRET}`;
 const gitHubStatusURL = `https://api.github.com/repos/${ calypsoProject }/statuses/`;
@@ -119,7 +119,7 @@ handler.on('pull_request', function (event) {
     }
 
     // canary test execution on label
-    if ( action === 'labeled' && ( label === canaryTriggerLabel || label === fullSuiteTriggerLabel ) ) {
+    if ( action === 'labeled' && ( label === calypsoCanaryTriggerLabel || label === calypsoFullSuiteTriggerLabel ) ) {
         const branchName = event.payload.pull_request.head.ref;
         let e2eBranchName, prContext, description, testFlag;
 
@@ -133,12 +133,12 @@ handler.on('pull_request', function (event) {
             } else {
                 e2eBranchName = 'master';
             }
-            if ( label === canaryTriggerLabel ) {
+            if ( label === calypsoCanaryTriggerLabel ) {
                 prContext = 'ci/wp-e2e-tests-canary';
                 testFlag = '-C';
                 description = 'The e2e canary tests are running against your PR';
                 console.log( 'Executing e2e canary tests for branch: \'' + branchName + '\'' );
-            } else if ( label === fullSuiteTriggerLabel ) {
+            } else if ( label === calypsoFullSuiteTriggerLabel ) {
                 prContext = 'ci/wp-e2e-tests-full';
                 testFlag = '-g';
                 description = 'The e2e full suite tests are running against your PR';

--- a/index.js
+++ b/index.js
@@ -7,9 +7,7 @@ const calypsoProject = process.env.CALYPSO_PROJECT || 'Automattic/wp-calypso';
 const e2eTestsMainProject = process.env.E2E_MAIN_PROJECT || 'Automattic/wp-e2e-tests';
 const e2eTestsWrapperProject = process.env.E2E_WRAPPER_PROJECT || 'Automattic/wp-e2e-tests-for-branches';
 const e2eTestsWrapperBranch = process.env.E2E_WRAPPER_BRANCH || 'master';
-const flowPatrolOnly = process.env.FLOW_PATROL_ONLY || 'false';
 
-const flowPatrolUsernames = [ 'alisterscott', 'brbrr', 'bsessions85', 'hoverduck', 'lancewillett', 'markryall', 'rachelmcr' ];
 const canaryTriggerLabel = process.env.TRIGGER_LABEL || '[Status] Needs Review';
 const fullSuiteTriggerLabel = process.env.FULL_SUITE_TRIGGER_LABEL || '[Status] Needs e2e Testing (BETA)';
 
@@ -101,12 +99,6 @@ handler.on('pull_request', function (event) {
     const action = event.payload.action;
     const prURL = event.payload.pull_request.url;
     const label = event.payload.label ? event.payload.label.name : null;
-
-    // Check if we should only run for certain users
-    if( flowPatrolOnly === 'true' && flowPatrolUsernames.indexOf( loggedInUsername ) === -1 ) {
-        console.log(  `Ignoring pull request '${ pullRequestNum }' as we're only running for certain users and '${ loggedInUsername }' is not in '${ flowPatrolUsernames }'` );
-        return true;
-    }
 
     // Make sure the PR is in the correct repository
     if ( repositoryName !== calypsoProject ) {


### PR DESCRIPTION
This adds support to execute Jetpack canary tests from the Jetpack project.

**Testing Instructions**

1. Create a **Jetpack** PR - note the branch name, eg. `try/livebranch-canary`
2. `export BRIDGE_SECRET='mysecret'`
3. `export CIRCLECI_SECRET='circlesecret'`
4. `export GITHUB_SECRET='githubkey'`
5. `export JETPACK_PROJECT=Automattic/wp-e2e-tests-gh-bridge` (this project)
6. `npm start`
7. `ngrok 7777`
8. Note the HTTPS address from ngrok and add this as a pull request webhook in this GH project
9. Create a new pull request with the exact same name as your Jetpack branch from step 1
9. Add the "[Status] Needs e2e Canary Testing" label to your new PR in this project

The e2e Jetpack canaries should execute and show the running status

**To test the statuses coming back from GitHub**
1. Open a PR for the https://github.com/Automattic/wp-e2e-tests-for-branches project and note the branch name
2. Update the webhook in circle.yml to be the ngrok address from your machine
3. Stop your local server process
4. `export E2E_WRAPPER_BRANCH=your-branch-name` with your branch name for the wp-e2e-tests-for-branches project
5. `npm start`
6. Re-execute tests by removing/adding a label again