### PR TITLE
Trigger full e2e suite on "Needs review" label

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const e2eCanaryTestsWrapperProject = process.env.E2E_WRAPPER_PROJECT || 'Automat
 const e2eFullTestsWrapperBranch = process.env.E2E_WRAPPER_BRANCH || 'master';
 const e2eCanaryTestsWrapperBranch = process.env.E2E_WRAPPER_BRANCH || 'master';
 
-const calypsoCanaryTriggerLabel = process.env.CALYPSO_TRIGGER_LABEL || '[Status] Needs Review';
+// const calypsoCanaryTriggerLabel = process.env.CALYPSO_TRIGGER_LABEL || '[Status] Needs Review';
 const calypsoFullSuiteTriggerLabel = process.env.CALYPSO_FULL_SUITE_TRIGGER_LABEL || '[Status] Needs e2e Testing' || '[Status] Needs Review';
 const calypsoFullSuiteHorizonTriggerLabel = process.env.CALYPSO_FULL_SUITE_HORIZON_TRIGGER_LABEL || '[Status] Needs e2e Testing horizon';
 const calypsoFullSuiteJetpackTriggerLabel = process.env.CALYPSO_FULL_SUITE_JETPACK_TRIGGER_LABEL || '[Status] Needs Jetpack e2e Testing';

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const e2eFullTestsWrapperBranch = process.env.E2E_WRAPPER_BRANCH || 'master';
 const e2eCanaryTestsWrapperBranch = process.env.E2E_WRAPPER_BRANCH || 'master';
 
 const calypsoCanaryTriggerLabel = process.env.CALYPSO_TRIGGER_LABEL || '[Status] Needs Review';
-const calypsoFullSuiteTriggerLabel = process.env.CALYPSO_FULL_SUITE_TRIGGER_LABEL || '[Status] Needs e2e Testing';
+const calypsoFullSuiteTriggerLabel = process.env.CALYPSO_FULL_SUITE_TRIGGER_LABEL || '[Status] Needs e2e Testing' || '[Status] Needs Review';
 const calypsoFullSuiteHorizonTriggerLabel = process.env.CALYPSO_FULL_SUITE_HORIZON_TRIGGER_LABEL || '[Status] Needs e2e Testing horizon';
 const calypsoFullSuiteJetpackTriggerLabel = process.env.CALYPSO_FULL_SUITE_JETPACK_TRIGGER_LABEL || '[Status] Needs Jetpack e2e Testing';
 const calypsoFullSuiteSecureAuthTriggerLabel = process.env.CALYPSO_FULL_SUITE_SECURE_AUTH_TRIGGER_LABEL || '[Status] Needs Secure Auth e2e Testing';

--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ const e2eCanaryTestsWrapperProject = process.env.E2E_WRAPPER_PROJECT || 'Automat
 const e2eFullTestsWrapperBranch = process.env.E2E_WRAPPER_BRANCH || 'master';
 const e2eCanaryTestsWrapperBranch = process.env.E2E_WRAPPER_BRANCH || 'master';
 
-const calypsoCanaryTriggerLabel = process.env.CALYPSO_TRIGGER_LABEL; // || '[Status] Needs Review';
-const calypsoFullSuiteTriggerLabel = process.env.CALYPSO_FULL_SUITE_TRIGGER_LABEL || '[Status] Needs e2e Testing' || '[Status] Needs Review';
+const calypsoCanaryTriggerLabel = process.env.CALYPSO_TRIGGER_LABEL || '[Status] Needs Review';
+const calypsoFullSuiteTriggerLabel = process.env.CALYPSO_FULL_SUITE_TRIGGER_LABEL || '[Status] Needs e2e Testing';
 const calypsoFullSuiteHorizonTriggerLabel = process.env.CALYPSO_FULL_SUITE_HORIZON_TRIGGER_LABEL || '[Status] Needs e2e Testing horizon';
 const calypsoFullSuiteJetpackTriggerLabel = process.env.CALYPSO_FULL_SUITE_JETPACK_TRIGGER_LABEL || '[Status] Needs Jetpack e2e Testing';
 const calypsoFullSuiteSecureAuthTriggerLabel = process.env.CALYPSO_FULL_SUITE_SECURE_AUTH_TRIGGER_LABEL || '[Status] Needs Secure Auth e2e Testing';
@@ -275,7 +275,7 @@ handler.on( 'pull_request', function( event ) {
 				e2eBranchName = branchName;
 			}
 
-			if ( labelsArray.includes( calypsoFullSuiteTriggerLabel ) ) {
+			if ( labelsArray.includes( calypsoFullSuiteTriggerLabel ) || labelsArray.includes( calypsoCanaryTriggerLabel )) {
 				description = 'The e2e full WPCOM suite desktop  tests are running against your PR';
 				log.info( 'Executing CALYPSO e2e full WPCOM suite desktop tests for branch: \'' + branchName + '\'' );
 				executeCircleCIBuild( 'true', '-S', branchName, e2eBranchName, pullRequestNum, 'ci/wp-e2e-tests-full-desktop', '-s desktop -g', description, sha, false, calypsoProject );

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const e2eCanaryTestsWrapperProject = process.env.E2E_WRAPPER_PROJECT || 'Automat
 const e2eFullTestsWrapperBranch = process.env.E2E_WRAPPER_BRANCH || 'master';
 const e2eCanaryTestsWrapperBranch = process.env.E2E_WRAPPER_BRANCH || 'master';
 
-// const calypsoCanaryTriggerLabel = process.env.CALYPSO_TRIGGER_LABEL || '[Status] Needs Review';
+const calypsoCanaryTriggerLabel = process.env.CALYPSO_TRIGGER_LABEL; // || '[Status] Needs Review';
 const calypsoFullSuiteTriggerLabel = process.env.CALYPSO_FULL_SUITE_TRIGGER_LABEL || '[Status] Needs e2e Testing' || '[Status] Needs Review';
 const calypsoFullSuiteHorizonTriggerLabel = process.env.CALYPSO_FULL_SUITE_HORIZON_TRIGGER_LABEL || '[Status] Needs e2e Testing horizon';
 const calypsoFullSuiteJetpackTriggerLabel = process.env.CALYPSO_FULL_SUITE_JETPACK_TRIGGER_LABEL || '[Status] Needs Jetpack e2e Testing';


### PR DESCRIPTION
This change triggers full suite e2e to start on `[Status] Needs review` label. 

To test:
- Run this branch locally 
- In Postman trigger request with a payload for wp-calypso PR
- Desktop and mobile tests started on wp-calypso PR?