### PR TITLE
Send new FORCE_ALL env var if the Needs e2e testing label is added.

### DIFF
--- a/index.js
+++ b/index.js
@@ -277,18 +277,19 @@ handler.on( 'pull_request', function( event ) {
 			}
 
 			if ( labelsArray.includes( calypsoFullSuiteTriggerLabel ) || labelsArray.includes( calypsoCanaryTriggerLabel ) ) {
+				const envVars = { FORCE_ALL: labelsArray.includes( calypsoFullSuiteTriggerLabel ) };
 				if ( user === 'renovate[bot]' ) {
 					description = 'The e2e full WPCOM suite of tests are running against your PR';
 					log.info( 'Executing CALYPSO e2e full WPCOM suite of tests for branch: \'' + branchName + '\'' );
-					executeCircleCIBuild( 'true', '-S', branchName, e2eBranchName, pullRequestNum, 'ci/wp-e2e-tests-full-renovate', '-g -p', description, sha, false, calypsoProject );
+					executeCircleCIBuild( 'true', '-S', branchName, e2eBranchName, pullRequestNum, 'ci/wp-e2e-tests-full-renovate', '-g -p', description, sha, false, calypsoProject, null, envVars );
 				} else {
 					description = 'The e2e full WPCOM suite desktop  tests are running against your PR';
 					log.info( 'Executing CALYPSO e2e full WPCOM suite desktop tests for branch: \'' + branchName + '\'' );
-					executeCircleCIBuild( 'true', '-S', branchName, e2eBranchName, pullRequestNum, 'ci/wp-e2e-tests-full-desktop', '-s desktop -g', description, sha, false, calypsoProject );
+					executeCircleCIBuild( 'true', '-S', branchName, e2eBranchName, pullRequestNum, 'ci/wp-e2e-tests-full-desktop', '-s desktop -g', description, sha, false, calypsoProject, null, envVars );
 
 					description = 'The e2e full WPCOM suite mobile tests are running against your PR';
 					log.info( 'Executing CALYPSO e2e full WPCOM suite mobile tests for branch: \'' + branchName + '\'' );
-					executeCircleCIBuild( 'true', '-S', branchName, e2eBranchName, pullRequestNum, 'ci/wp-e2e-tests-full-mobile', '-s mobile -g', description, sha, false, calypsoProject );
+					executeCircleCIBuild( 'true', '-S', branchName, e2eBranchName, pullRequestNum, 'ci/wp-e2e-tests-full-mobile', '-s mobile -g', description, sha, false, calypsoProject, null, envVars );
 				}
 			}
 


### PR DESCRIPTION
This PR sends a new env var that will let the wrapper repo determine if ALL signup tests should be run. 

To Test:
Run this locally with `E2E_WRAPPER_BRANCH` env var set to `try/split-signup-tests`
Post payload to it.  With and without label `[Status] Needs e2e Testing`, and with and without changes in `/client/blocks/signup-form`, `/client/lib/signup`, and/or  `/client/signup`