### PR TITLE
Add: webhook handling for gutenberg edge label

### DIFF
--- a/index.js
+++ b/index.js
@@ -323,11 +323,11 @@ handler.on( 'pull_request', function( event ) {
 				const envVars = { SKIP_DOMAIN_TESTS: true, GUTENBERG_EDGE: true };
 				description = 'The e2e full WPCOM suite desktop tests are running against your PR with the latest snapshot of Gutenberg';
 				log.info( 'Executing CALYPSO e2e full WPCOM suite desktop tests for with gutenberg edge branch: \'' + branchName + '\'' );
-				executeCircleCIBuild( 'false', '', '', e2eBranchName, pullRequestNum, 'ci/wp-e2e-tests-full-desktop', `-s desktop -g`, description, sha, false, calypsoProject, null, envVars );
+				executeCircleCIBuild( 'false', '', '', e2eBranchName, pullRequestNum, 'ci/wp-e2e-tests-full-desktop-edge', '-s desktop -g', description, sha, false, calypsoProject, null, envVars );
 
 				description = 'The e2e full WPCOM suite desktop tests are running against your PR with the latest snapshot of Gutenberg';
 				log.info( 'Executing CALYPSO e2e full WPCOM suite mobile tests with gutenberg edge for branch: \'' + branchName + '\'' );
-				executeCircleCIBuild( 'false', '', '', e2eBranchName, pullRequestNum, 'ci/wp-e2e-tests-full-mobile', `-s mobile -g`, description, sha, false, calypsoProject, null, envVars );
+				executeCircleCIBuild( 'false', '', '', e2eBranchName, pullRequestNum, 'ci/wp-e2e-tests-full-mobile-edge', '-s mobile -g', description, sha, false, calypsoProject, null, envVars );
 			}
 		} );
 	} else if ( ( action === 'labeled' || action === 'synchronize' ) && repositoryName === jetpackProject && labelsArray.includes( jetpackCanaryTriggerLabel ) ) { // Jetpack test execution on label


### PR DESCRIPTION
WIP

Let's trigger a full desktop and mobile E2E run using a special test site that has the `gutenberg-edge` blog sticker. This loads the latest version of the Gutenberg plugin we're testing in all views (iframe/wp-admin/published) so we should be able to add more types of E2E tests!

- [x] Create a new wp-calypso label [[Status] Needs e2e Testing Gutenberg Edge](https://github.com/Automattic/wp-calypso/labels/%5BStatus%5D%20Needs%20e2e%20Testing%20Gutenberg%20Edge)
- [ ] Create a new site, apply the `gutenberg-edge` sticker
- [ ] Map new env options in E2E
- [ ] Update this PR with the right options to pass through
