### PR TITLE
Run tests against live branch for Edge user

### DIFF
--- a/index.js
+++ b/index.js
@@ -323,11 +323,11 @@ handler.on( 'pull_request', function( event ) {
 				const envVars = { SKIP_DOMAIN_TESTS: true, GUTENBERG_EDGE: true };
 				description = 'The e2e full WPCOM suite desktop tests are running against your PR with the latest snapshot of Gutenberg';
 				log.info( 'Executing CALYPSO e2e full WPCOM suite desktop tests for with gutenberg edge branch: \'' + branchName + '\'' );
-				executeCircleCIBuild( 'false', '', '', e2eBranchName, pullRequestNum, 'ci/wp-e2e-tests-full-desktop-edge', '-s desktop -g', description, sha, false, calypsoProject, null, envVars );
+				executeCircleCIBuild( 'true', '-S', branchName, e2eBranchName, pullRequestNum, 'ci/wp-e2e-tests-full-desktop-edge', '-s desktop -g', description, sha, false, calypsoProject, null, envVars );
 
 				description = 'The e2e full WPCOM suite desktop tests are running against your PR with the latest snapshot of Gutenberg';
 				log.info( 'Executing CALYPSO e2e full WPCOM suite mobile tests with gutenberg edge for branch: \'' + branchName + '\'' );
-				executeCircleCIBuild( 'false', '', '', e2eBranchName, pullRequestNum, 'ci/wp-e2e-tests-full-mobile-edge', '-s mobile -g', description, sha, false, calypsoProject, null, envVars );
+				executeCircleCIBuild( 'true', '-S', branchName, e2eBranchName, pullRequestNum, 'ci/wp-e2e-tests-full-mobile-edge', '-s mobile -g', description, sha, false, calypsoProject, null, envVars );
 			}
 		} );
 	} else if ( ( action === 'labeled' || action === 'synchronize' ) && repositoryName === jetpackProject && labelsArray.includes( jetpackCanaryTriggerLabel ) ) { // Jetpack test execution on label


### PR DESCRIPTION
This change will enable e2e tests to run against live branch for Gutenberg Edge user (discussed in https://github.com/Automattic/wp-e2e-tests-gh-bridge/pull/82#pullrequestreview-336176527).

 I tested this change against [dummy PR](https://github.com/Automattic/wp-calypso/pull/38582) and jobs for Edge user have set `BRANCHNAME` which were missing before. More context what was the issue - https://github.com/Automattic/wp-calypso/pull/38507#issuecomment-568528707

<img width="492" alt="Screen Shot 2019-12-24 at 14 40 03" src="https://user-images.githubusercontent.com/7116222/71415327-5fd69800-265b-11ea-9e64-75d21e935e6f.png">
